### PR TITLE
[Issue #15] feat: persist LTE reboot state before forced reboot.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM livekit/gstreamer:1.24.5-prod-rs
 RUN apt-get update && apt-get install -y \
     iproute2 \
     iputils-ping \
+    network-manager \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/internet_monitor.sh
+++ b/internet_monitor.sh
@@ -10,6 +10,11 @@ TIME_LIMIT=$((THRESHOLD_TIME * 60))
 # Read interface names from environment variables
 ETHERNET_IFACE=${ETHERNET_INTERFACE_NAME}
 LTE_IFACE=${LTE_INTERFACE_NAME}
+WWAN_CONTROL_DEVICE=${WAN_CONTROL_DEVICE:-cdc-wdm0}
+
+# Persistent reboot state shared with nm-carrier-manager
+STATE_DIR=${STATE_DIR:-/var/lib/va-state}
+STATE_FILE=${STATE_FILE:-/var/lib/va-state/state.env}
 
 # Initialize
 THRESHOLD=$MAX_THRESHOLD_COUNT
@@ -21,6 +26,7 @@ WATCHDOG_DEV="/dev/watchdog"
 # set true/1/yes to enable watchdog
 WATCHDOG_ENABLE=${WATCHDOG_ENABLE:-0}
 LOG_LEVEL=$(echo "${LOG_LEVEL:-ERROR}" | tr '[:lower:]' '[:upper:]')
+
 
 # Map log levels to numeric values for easy comparison
 log_level_value() {
@@ -50,6 +56,58 @@ log() {
     fi
 
     echo "$(date '+%Y-%m-%d %H:%M:%S') - ${level} - $message"
+}
+
+get_active_nm_connection_from_device() {
+    dev="$1"
+    [ -z "$dev" ] && return 0
+
+    conn=$(nmcli -t -f GENERAL.CONNECTION device show "$dev" 2>/dev/null | head -n 1 | cut -d: -f2-)
+    if [ -n "$conn" ] && [ "$conn" != "--" ]; then
+        printf "%s" "$conn"
+    fi
+}
+
+get_active_lte_connection() {
+    conn=$(get_active_nm_connection_from_device "$LTE_IFACE")
+    if [ -n "$conn" ]; then
+        printf "%s" "$conn"
+        return 0
+    fi
+
+    conn=$(get_active_nm_connection_from_device "$WWAN_CONTROL_DEVICE")
+    if [ -n "$conn" ]; then
+        printf "%s" "$conn"
+        return 0
+    fi
+
+    printf "%s" ""
+}
+
+write_lte_reboot_state() {
+    mkdir -p "$STATE_DIR"
+
+    count=0
+    if [ -f "$STATE_FILE" ]; then
+        . "$STATE_FILE" 2>/dev/null || true
+        if [ "${CAUSE:-}" = "lte_no_internet_reboot" ]; then
+            count=${COUNT:-0}
+        fi
+    fi
+
+    count=$((count + 1))
+    saved_connection="$(get_active_lte_connection)"
+    safe_saved_connection=$(printf "%s" "$saved_connection" | sed "s/'/'\\\\''/g")
+
+    {
+        echo "CAUSE='lte_no_internet_reboot'"
+        echo "COUNT='${count}'"
+        echo "SAVED_CONNECTION='${safe_saved_connection}'"
+        echo "TIMESTAMP='$(date -u +%Y-%m-%dT%H:%M:%SZ)'"
+    } > "$STATE_FILE"
+
+    sync
+    log ALERT "Saved LTE reboot state: COUNT=${count}, SAVED_CONNECTION=${saved_connection:-none}"
 }
 
 # Enable sysrq for reboot
@@ -142,10 +200,10 @@ while true; do
         # At least one is up → increase threshold
         THRESHOLD=$((THRESHOLD + SUCCESS_INCREMENT_FACTOR))
         INITIAL_FAIL_TIME=0
+
     fi
 
     # Clamp THRESHOLD between 0 and MAX
-
     if [ "$THRESHOLD" -gt "$MAX_THRESHOLD_COUNT" ]; then
         THRESHOLD=$MAX_THRESHOLD_COUNT
     fi
@@ -156,10 +214,12 @@ while true; do
 
     if [ "$THRESHOLD" -le 0 ]; then
 	log ALERT "THRESHOLD is 0. Rebooting now..."
+	write_lte_reboot_state
 	sync
 	echo b > /proc/sysrq-trigger
     elif [ "$INITIAL_FAIL_TIME" -ne 0 ] && [ $((current_time - INITIAL_FAIL_TIME)) -ge "$TIME_LIMIT" ]; then
             log ALERT "Internet down too long while THRESHOLD > 0. Rebooting..."
+	    write_lte_reboot_state
             sync
             echo b > /proc/sysrq-trigger
     

--- a/internet_monitor.sh
+++ b/internet_monitor.sh
@@ -75,7 +75,7 @@ write_lte_reboot_state() {
 
     count=0
     if [ -f "$STATE_FILE" ]; then
-        . "$STATE_FILE" 2>/dev/null || true
+        . "$STATE_FILE" 2>/dev/null
         if [ "${CAUSE:-}" = "lte_no_internet_reboot" ]; then
             count=${COUNT:-0}
         fi
@@ -83,17 +83,15 @@ write_lte_reboot_state() {
 
     count=$((count + 1))
     saved_connection="$(get_active_nm_connection_from_device "$WWAN_CONTROL_DEVICE")"
-    safe_saved_connection=$(printf "%s" "$saved_connection" | sed "s/'/'\\\\''/g")
 
     {
         echo "CAUSE='lte_no_internet_reboot'"
         echo "COUNT='${count}'"
-        echo "SAVED_CONNECTION='${safe_saved_connection}'"
+        echo "SAVED_CONNECTION='${saved_connection}'"
         echo "TIMESTAMP='$(date -u +%Y-%m-%dT%H:%M:%SZ)'"
     } > "$STATE_FILE"
 
     log ALERT "Saved LTE reboot state: COUNT=${count}, SAVED_CONNECTION=${saved_connection:-none}"
-    sync
 }
 
 # Enable sysrq for reboot
@@ -186,7 +184,6 @@ while true; do
         # At least one is up → increase threshold
         THRESHOLD=$((THRESHOLD + SUCCESS_INCREMENT_FACTOR))
         INITIAL_FAIL_TIME=0
-
     fi
 
     # Clamp THRESHOLD between 0 and MAX

--- a/internet_monitor.sh
+++ b/internet_monitor.sh
@@ -59,10 +59,9 @@ log() {
 
 get_active_nm_connection_from_device() {
     dev="$1"
-    [ -z "$dev" ] && return 0
 
     conn=$(nmcli -t -f GENERAL.CONNECTION device show "$dev" 2>/dev/null | cut -d: -f2)
-    if [ -n "$conn" ] && [ "$conn" != "--" ]; then
+    if [ -n "$conn" ]; then
         printf "%s" "$conn"
     fi
 }
@@ -187,6 +186,7 @@ while true; do
     fi
 
     # Clamp THRESHOLD between 0 and MAX
+
     if [ "$THRESHOLD" -gt "$MAX_THRESHOLD_COUNT" ]; then
         THRESHOLD=$MAX_THRESHOLD_COUNT
     fi

--- a/internet_monitor.sh
+++ b/internet_monitor.sh
@@ -27,7 +27,6 @@ WATCHDOG_DEV="/dev/watchdog"
 WATCHDOG_ENABLE=${WATCHDOG_ENABLE:-0}
 LOG_LEVEL=$(echo "${LOG_LEVEL:-ERROR}" | tr '[:lower:]' '[:upper:]')
 
-
 # Map log levels to numeric values for easy comparison
 log_level_value() {
     case "$1" in
@@ -62,30 +61,17 @@ get_active_nm_connection_from_device() {
     dev="$1"
     [ -z "$dev" ] && return 0
 
-    conn=$(nmcli -t -f GENERAL.CONNECTION device show "$dev" 2>/dev/null | head -n 1 | cut -d: -f2-)
+    conn=$(nmcli -t -f GENERAL.CONNECTION device show "$dev" 2>/dev/null | cut -d: -f2)
     if [ -n "$conn" ] && [ "$conn" != "--" ]; then
         printf "%s" "$conn"
     fi
 }
 
-get_active_lte_connection() {
-    conn=$(get_active_nm_connection_from_device "$LTE_IFACE")
-    if [ -n "$conn" ]; then
-        printf "%s" "$conn"
-        return 0
-    fi
-
-    conn=$(get_active_nm_connection_from_device "$WWAN_CONTROL_DEVICE")
-    if [ -n "$conn" ]; then
-        printf "%s" "$conn"
-        return 0
-    fi
-
-    printf "%s" ""
-}
-
 write_lte_reboot_state() {
-    mkdir -p "$STATE_DIR"
+    if [ ! -d "$STATE_DIR" ]; then
+        log ERROR "State directory does not exist: $STATE_DIR"
+        return 1
+    fi
 
     count=0
     if [ -f "$STATE_FILE" ]; then
@@ -96,7 +82,7 @@ write_lte_reboot_state() {
     fi
 
     count=$((count + 1))
-    saved_connection="$(get_active_lte_connection)"
+    saved_connection="$(get_active_nm_connection_from_device "$WWAN_CONTROL_DEVICE")"
     safe_saved_connection=$(printf "%s" "$saved_connection" | sed "s/'/'\\\\''/g")
 
     {
@@ -106,8 +92,8 @@ write_lte_reboot_state() {
         echo "TIMESTAMP='$(date -u +%Y-%m-%dT%H:%M:%SZ)'"
     } > "$STATE_FILE"
 
-    sync
     log ALERT "Saved LTE reboot state: COUNT=${count}, SAVED_CONNECTION=${saved_connection:-none}"
+    sync
 }
 
 # Enable sysrq for reboot


### PR DESCRIPTION
### Summary
This PR introduces persistent LTE reboot state tracking in the internet-monitor service.
Whenever a forced reboot is triggered due to LTE internet failure (threshold/time limit), the system now captures and stores reboot context so that nm-carrier-manager can make informed recovery decisions after boot.

### Changes

1. State Persistence
Introduced configurable paths:
STATE_DIR (default: /var/lib/va-state)
STATE_FILE (default: /var/lib/va-state/state.env)
Added write_lte_reboot_state() to persist reboot metadata.

2. Reboot Context Captured
    The following fields are stored before reboot:
    - CAUSE=lte_no_internet_reboot
    - COUNT (incremented across consecutive LTE failures)
    - SAVED_CONNECTION (active LTE profile via nmcli)
    - TIMESTAMP (UTC)

3. LTE Connection Detection
Added helper function to fetch active NetworkManager connection:
Uses nmcli on WAN_CONTROL_DEVICE (default: cdc-wdm0)

4. Reboot Flow Update
    State persistence is executed before reboot in:
    - Threshold-based reboot (THRESHOLD <= 0)
    - Time-limit reboot (failure duration >= TIME_LIMIT)

5. Logging
    Added ALERT-level log for saved reboot state.

```

2026-04-22 08:20:02 - WARNING - Internet down on both Interfaces. Failure duration: 244 seconds (4 min).
2026-04-22 08:20:12 - INFO - wan-usb0 Loss: 100%
2026-04-22 08:20:17 - INFO - wwan0 Loss: 100%
2026-04-22 08:20:17 - INFO - THRESHOLD=10
2026-04-22 08:20:17 - WARNING - Internet down on both Interfaces. Failure duration: 259 seconds (4 min).
2026-04-22 08:20:27 - INFO - wan-usb0 Loss: 100%
2026-04-22 08:20:33 - INFO - wwan0 Loss: 100%
2026-04-22 08:20:33 - INFO - THRESHOLD=0
2026-04-22 08:20:33 - ALERT - THRESHOLD is 0. Rebooting now...
2026-04-22 08:20:33 - ALERT - Saved LTE reboot state: COUNT=2, SAVED_CONNECTION=quectel_connection

```

### Acceptance Criteria
 - state.env is created/updated before reboot
 - CAUSE=lte_no_internet_reboot is persisted
 - COUNT increments across consecutive LTE reboots
 - SAVED_CONNECTION is populated when available
 - Existing reboot behavior remains unchanged


